### PR TITLE
Update deprecated NavigationToolbar2TkAgg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+

--- a/cpgui_diagram.py
+++ b/cpgui_diagram.py
@@ -8,7 +8,7 @@ import sys
 from tkinter import *
 from tkinter import ttk
 
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.backend_bases import key_press_handler
 import matplotlib.ticker as mplticker
 from matplotlib.figure import Figure


### PR DESCRIPTION
I tried running the app on Fedora 31 (Python 3.7.6) and found that the `NavigationToolbar2TkAgg` had changed.

* Update deprecated NavigationToolbar2TkAgg
* Add gitignore